### PR TITLE
Fix Matched Trials Component Refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,7 @@
                 "flux": "2.1.1",
                 "focus-trap-react": "^3.0.5",
                 "fuse.js": "^2.2.0",
+                "gemini-scrollbar": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b",
                 "gfm.css": "^1.1.1",
                 "glob": "^5.0.14",
                 "highlight.js": "^9.13.0",
@@ -126,13 +127,16 @@
                 "react-addons-css-transition-group": "15.3.2",
                 "react-beautiful-dnd": "^4.0.1",
                 "react-dom": "^15.6.0",
+                "react-gemini-scrollbar": "github:matrix-org/react-gemini-scrollbar#5e97aef7e034efc8db1431f4b0efe3b26e249ae9",
                 "resize-observer-polyfill": "^1.5.0",
                 "sanitize-html": "^1.18.4",
                 "slate": "^0.41.2",
                 "slate-html-serializer": "^0.6.1",
+                "slate-md-serializer": "github:matrix-org/slate-md-serializer#f7c4ad394f5af34d4c623de7909ce95ab78072d3",
                 "slate-react": "^0.18.10",
                 "text-encoding-utf-8": "^1.0.1",
                 "url": "^0.11.0",
+                "velocity-vector": "github:vector-im/velocity#059e3b2348f1110888d033974d3109fd5a3af00f",
                 "whatwg-fetch": "^1.1.1"
             },
             "dependencies": {
@@ -143,7 +147,7 @@
                 },
                 "gemini-scrollbar": {
                     "version": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b",
-                    "from": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b"
+                    "from": "github:matrix-org/gemini-scrollbar#b302279"
                 },
                 "glob": {
                     "version": "5.0.15",
@@ -155,30 +159,6 @@
                         "minimatch": "2 || 3",
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "react-gemini-scrollbar": {
-                    "version": "github:matrix-org/react-gemini-scrollbar#5e97aef7e034efc8db1431f4b0efe3b26e249ae9",
-                    "from": "github:matrix-org/react-gemini-scrollbar#5e97aef7e034efc8db1431f4b0efe3b26e249ae9",
-                    "requires": {
-                        "gemini-scrollbar": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b"
-                    },
-                    "dependencies": {
-                        "gemini-scrollbar": {
-                            "version": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b",
-                            "from": "github:matrix-org/gemini-scrollbar#b302279"
-                        }
-                    }
-                },
-                "slate-md-serializer": {
-                    "version": "github:matrix-org/slate-md-serializer#f7c4ad394f5af34d4c623de7909ce95ab78072d3",
-                    "from": "github:matrix-org/slate-md-serializer#f7c4ad394f5af34d4c623de7909ce95ab78072d3"
-                },
-                "velocity-vector": {
-                    "version": "github:vector-im/velocity#059e3b2348f1110888d033974d3109fd5a3af00f",
-                    "from": "github:vector-im/velocity#059e3b2348f1110888d033974d3109fd5a3af00f",
-                    "requires": {
-                        "jquery": ">= 1.4.3"
                     }
                 },
                 "whatwg-fetch": {
@@ -23364,6 +23344,13 @@
             "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.0.tgz",
             "integrity": "sha512-akMy/BQT5m1J3iJIHkSb4qycq2wzllWsmmolaaFVnb+LPV9cIJ/nTud40ZsiiT0H3P+/wXIdbjx2fzF61OaeOQ=="
         },
+        "react-gemini-scrollbar": {
+            "version": "github:matrix-org/react-gemini-scrollbar#5e97aef7e034efc8db1431f4b0efe3b26e249ae9",
+            "from": "github:matrix-org/react-gemini-scrollbar#5e97aef",
+            "requires": {
+                "gemini-scrollbar": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b"
+            }
+        },
         "react-immutable-proptypes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz",
@@ -26876,6 +26863,10 @@
                 "type-of": "^2.0.1"
             }
         },
+        "slate-md-serializer": {
+            "version": "github:matrix-org/slate-md-serializer#f7c4ad394f5af34d4c623de7909ce95ab78072d3",
+            "from": "github:matrix-org/slate-md-serializer#f7c4ad3"
+        },
         "slate-plain-serializer": {
             "version": "0.6.33",
             "resolved": "https://registry.npmjs.org/slate-plain-serializer/-/slate-plain-serializer-0.6.33.tgz",
@@ -29105,6 +29096,13 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+        },
+        "velocity-vector": {
+            "version": "github:vector-im/velocity#059e3b2348f1110888d033974d3109fd5a3af00f",
+            "from": "github:vector-im/velocity#059e3b2",
+            "requires": {
+                "jquery": ">= 1.4.3"
+            }
         },
         "vendors": {
             "version": "1.0.2",

--- a/src/components/structures/AlohaClinicalTrialListView.js
+++ b/src/components/structures/AlohaClinicalTrialListView.js
@@ -14,6 +14,12 @@ import gql from 'graphql-tag'
 import AlohaClinicalTrialList from '@alohahealth/aloha-react-sdk/lib/AlohaClinicalTrialList'
 
 module.exports = React.createClass({
+  // This is a temporary fix for the component always getting re-rendered every time AlohaLoggedInView.onSync is called
+  // TODO: (adam) Does this class inherit/acquire shouldComponentUpdate from AlohaLoggedInView? Is this the best approach?
+  shouldComponentUpdate: function () {
+    return false
+  },
+
   render: function() {
     /*
      * Retrieve user's matched clinical trials


### PR DESCRIPTION
It appears that `AlohaClinicalTrialListView.shouldComponentUpdate()`is called in coordination with the `AlohaLoggedInView.onSync()` handler.

I'm not sure how these are related but it seems like this is at least a temporary fix for the issue.